### PR TITLE
docs: Improve description of verbose functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Options
   -c, --chromium_params   Optional parameters to pass to chrome/chromium browser
                             (https://peter.sh/experiments/chromium-command-line-switches/)
                             (example: "--no-sandbox --disable-setuid-sandbox --ssl-version-max=tls1.1")
-  -v, --verbose           The more you add, the more it show information
+  -v, --verbose           Providing this option once will show more info from Lighthouse.
+                            Providing it twice will additionally provide info from `lighthouse-batch`.
   -h, --help              Print this usage guide.
 
 Lighthouse

--- a/bin/lighthouse-puppeteer.js
+++ b/bin/lighthouse-puppeteer.js
@@ -55,7 +55,8 @@ const optionDefinitions = [
     {
         name: 'verbose',
         alias: 'v',
-        description: 'Providing this option once will show more info from Lighthouse. Providing it twice will additionally provide info from `lighthouse-batch`.',
+        description: 'Providing this option once will show more info from Lighthouse.' +
+                     '\nProviding it twice will additionally provide info from `lighthouse-batch`.',
         type: Boolean,
         multiple: true,
         group: 'main',

--- a/bin/lighthouse-puppeteer.js
+++ b/bin/lighthouse-puppeteer.js
@@ -55,7 +55,7 @@ const optionDefinitions = [
     {
         name: 'verbose',
         alias: 'v',
-        description: 'The more you add, the more it show information',
+        description: 'Providing this option once will show more info from Lighthouse. Providing it twice will additionally provide info from `lighthouse-batch`.',
         type: Boolean,
         multiple: true,
         group: 'main',


### PR DESCRIPTION
A bit more info in the verbose description, to let users know they can get more info to debug, as well as where the debug info is coming from.

This is how I discovered that the chromium and lighthouse params were not being passed on.