### PR TITLE
Lighthouse and chromium params not passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options
   -p, --port PORT         Chrome headless debug port (default: 9222)
   -c, --chromium_params   Optional parameters to pass to chrome/chromium browser
                             (https://peter.sh/experiments/chromium-command-line-switches/)
-                            (example: "--no-sandbox --disable-setuid-sandbox --ssl-version-max=tls1.1")
+                            (example: "- --no-sandbox --disable-setuid-sandbox --ssl-version-max=tls1.1")
   -v, --verbose           The more you add, the more it show information
   -h, --help              Print this usage guide.
 
@@ -53,7 +53,7 @@ Lighthouse
   -w, --html                      Renders HTML reports alongside JSON reports
   -l, --lighthouse_params         Optional parameters to pass to lighthouse
                                   (https://github.com/GoogleChrome/lighthouse/#cli-options)
-                                  (example: "--quiet --perf")
+                                  (example: "- --quiet --perf")
 
 Puppeteer
 

--- a/bin/lighthouse-puppeteer.js
+++ b/bin/lighthouse-puppeteer.js
@@ -41,7 +41,7 @@ const optionDefinitions = [
         alias: 'l',
         description: 'Optional parameters to pass to lighthouse' +
             '\n(https://github.com/GoogleChrome/lighthouse/#cli-options)' +
-            '\n({italic example}: "--quiet --perf")',
+            '\n({italic example}: "- --quiet --perf")',
         group: 'lighthouse'
     },
     {
@@ -49,7 +49,7 @@ const optionDefinitions = [
         alias: 'c',
         description: 'Optional parameters to pass to chrome/chromium browser' +
             '\n(https://peter.sh/experiments/chromium-command-line-switches/)' +
-            '\n({italic example}: "--no-sandbox --disable-setuid-sandbox --ssl-version-max=tls1.1")',
+            '\n({italic example}: "- --no-sandbox --disable-setuid-sandbox --ssl-version-max=tls1.1")',
         group: 'main'
     },
     {


### PR DESCRIPTION

Running with the additional dash `-` for `-l` or `-c` allows the arguments to be passed. Without it, the arguments seems to be swallowed.

```shell
$ docker run --rm --name perf -it  -v /Users/development/:/home/chrome/reports -v /Users/development/test/lighthouse/:/home/chrome/testcases --security-opt seccomp=/Users/development/ui-/test/lighthouse/chrome.json femtopixel/google-lighthouse-puppeteer auth-login -l "- --preset=desktop --only-categories=accessibility,best-practices,performance,seo" --verbose -v --html
```

```shell
...
3/3: Lighthouse analyzing '<website>'
"<website>" --output json --output html --output-path "/home/chrome/reports/<website>" --chrome-flags="--no-sandbox --headless --disable-gpu" --port 9222 - --preset=desktop --only-categories=accessibility,best-practices,performance,seo
...
```

Without the dash:

```shell
$ docker run --rm --name perf -it  -v /Users/development/:/home/chrome/reports -v /Users/development/test/lighthouse/:/home/chrome/testcases --security-opt seccomp=/Users/development/ui-/test/lighthouse/chrome.json femtopixel/google-lighthouse-puppeteer auth-login -l "--preset=desktop --only-categories=accessibility,best-practices,performance,seo" --verbose -v --html
```

```shell
...
3/3: Lighthouse analyzing '<website>'
"<website>" --output json --output html --output-path "/home/chrome/reports/<website>" --chrome-flags="--no-sandbox --headless --disable-gpu" --port 9222
...
```

This issue seems to have a suggested solution in the [`command-line-args` repo ](https://github.com/75lb/command-line-args/wiki/Terminate-parsing-with-a-double-hypen), but I guess using just a single dash works for now, although it might break in newer versions of `command-line-args`, as it is an undocumented workaround.